### PR TITLE
Provide method name to TaskInterface

### DIFF
--- a/src/Qutee/Worker.php
+++ b/src/Qutee/Worker.php
@@ -213,16 +213,16 @@ class Worker
         }
 
         $taskObject     = new $taskClassName;
-
+        $methodName     = $task->getMethodName();
+        
         if ($taskObject instanceof TaskInterface) {
 
             $taskObject->setData($task->getData());
-            $taskObject->run();
+            $taskObject->run($methodName);
             return $taskObject;
 
         } else {
 
-            $methodName     = $task->getMethodName();
             $taskObject->$methodName($task->getData());
 
         }


### PR DESCRIPTION
allows for the task object to take the form
```
class myTask implements TaskInterface {
    protected $_data;
    public function run($methodName='')
    {
        if(method_exists($this, $methodName)){
            return call_user_func_array(array($this, $methodName), $this->_data);
        }
        return false;
    }

    public function setData(array $data)
    {
        $this->_data = $data;
    }

    protected function myMethodThatReceivesTheDataSetAsParameters($param1, $param2)
    {
        echo "$param1 \n";
        echo "$param2 \n";
    }
}
```