### PR TITLE
Long running process race condition

### DIFF
--- a/src/Qutee/Persistor/Pdo.php
+++ b/src/Qutee/Persistor/Pdo.php
@@ -240,7 +240,7 @@ class Pdo implements PersistorInterface
      *
      * @throws \Qutee\Persistor\PDOException
      */
-    protected function _testConnection(\PDO $pdo)
+    protected function _testConnection(\PDO &$pdo)
     {
         try {
             // Dummy query


### PR DESCRIPTION
Trying to recreate a task after a long running process ends in a race condition in the pdo module (actually any db calls through the pdo module for this task)

When you pass the pdo object to the `_testConnection(\PDO $pdo)` function its actually receives the value of the reference to the pdo object.
Setting it to null in the catch statement doesn't set `$this->_pdo = null;` only the local `$pdo` variable
You need to pass it a reference to the reference

To test firstly see what you're mysql timeouts are set to using
```
SHOW VARIABLES LIKE 'wait_timeout';
SHOW VARIABLES LIKE 'interactive_timeout';
```
put a sleep in your test task longer than the largest one (its in seconds)
see a race condition as `$this->_testConnection()` calls `$this->_getPdo();` while `$this->_pdo` stays not null.... and repeat

At least this is so in php v5.6.32
mh